### PR TITLE
fix(debugger): debugger gets disconnected immediately after attaching (temp fix)

### DIFF
--- a/src/services/attach-service.ts
+++ b/src/services/attach-service.ts
@@ -136,7 +136,10 @@ export default class AttachService implements Disposable {
     });
     if (matchedProcesses.length > 0) {
       //try detect if it's due to restart
-      DotNetWatch.DebugService.DisconnectOldDotNetDebugger(matchedProcesses);
+
+			// Debugger gets attached and disconnected immediately, so this is why I commented this line.
+			// FIXME!
+      // DotNetWatch.DebugService.DisconnectOldDotNetDebugger(matchedProcesses);
     }
   }
 

--- a/src/services/process-service.ts
+++ b/src/services/process-service.ts
@@ -52,7 +52,7 @@ export default class ProcessService implements Disposable {
     const cmlPattern = /^([0-9]+)\s+([0-9]+)\s(.+$)/;
 
     // build and execute command line tool "ps" to get details of all running processes
-    const args = ["-o pid,ppid,command"];
+    const args = ["-e -o pid,ppid,command"];
 		const tmp = child_process.execSync(`ps ${args}`).toString();
 
     // split process informations results for each process


### PR DESCRIPTION
Please see [this](https://github.com/murugaratham/vscode-dotnet-watch/issues/10) issue for more info.